### PR TITLE
Fix FreeBSD install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Install the package:
 
 .. code-block::
 
-    pkg install toot
+    pkg install py36-toot
 
 Build and install from sources:
 


### PR DESCRIPTION
As mentioned https://www.freshports.org/net-im/toot/ the port name is `toot` but the package name is `py36-toot`.